### PR TITLE
Django 4: CSRF_TRUSTED_ORIGINS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build image
 on:
-  - release
+  - published
   - workflow_dispatch
 permissions:
   packages: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ TBD
 
 ### Added
 
-#3 fix for dependabot alerts
+fix for dependabot alerts
 
 # 1.0.0 2024-06-04
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ and replace/insert values for the keys listed below with your own.
       python3 -c "import secrets; print(secrets.token_urlsafe(50))"
       ```
 - **DJANGO_ALLOWED_HOSTS** - The list of names to which this server will respond (defaults sufficient for local/dev installations; add/replace for public access)
+- **CSRF_TRUSTED_ORIGINS** - The list of URLs to which this server will respond; each URL should have a scheme (https for example) and a port number if applicable
 - **POSTGRES_DB** - The preferred name of the created database
 - **POSTGRES_USER** - The username for the database
 - **POSTGRES_PASSWORD** - The password for the database

--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -92,7 +92,8 @@ LABEL org.opencontainers.image.description="GREN Map Database Node - django imag
 
 # Write a file containing the build attributes.
 # Django will read it to populate the home admin page.
-RUN SECRET_KEY=None python manage.py buildinfo ${GIT_COMMIT:-""} ${GIT_TAG:-""}
+RUN SECRET_KEY=None CSRF_TRUSTED_ORIGINS="https://map1.example.com" \
+python manage.py buildinfo ${GIT_COMMIT:-""} ${GIT_TAG:-""}
 
 # run entrypoint.sh
 ENTRYPOINT ["/home/grenmapadmin/web/entrypoint.sh"]

--- a/django/base_app/settings.py
+++ b/django/base_app/settings.py
@@ -60,6 +60,8 @@ TEST_MODE = DEBUG
 # ALLOWED_HOSTS = []
 ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', default='').split(' ')
 
+CSRF_TRUSTED_ORIGINS = os.environ.get('CSRF_TRUSTED_ORIGINS', default='').split(' ')
+
 DJANGO_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/django/run_tests_with_sqlite.sh
+++ b/django/run_tests_with_sqlite.sh
@@ -2,5 +2,6 @@
 
 export SECRET_KEY=$(echo $RANDOM | md5sum | head -c 20)
 export SQL_ENGINE=django.db.backends.sqlite3
+export CSRF_TRUSTED_ORIGINS="https://map1.example.com"
 python manage.py migrate
 pytest --no-cov --tb=no


### PR DESCRIPTION
django/base_app/settings.py
django/Dockerfile
django/run_tests_with_sqlite.sh
README.md:
The default CSRF check implemented in Django 4 requires a list of allowed origins. We will use an environment variable to pass it to the server.

CHANGELOG.md:
The dependabot item was not a GitHub issue. It should not have an issue id.

.github/workflows/build.yml:
This should stop GitHub from spawning three build jobs when we create a release.