### PR TITLE
build action: latest tag missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
       - name: pull code
         uses: actions/checkout@v4
 
+      - run: git fetch --prune --unshallow
+
       - name: set up docker buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
I ran the build action to obtain a fresh image then noticed `git describe` had not returned the latest tag.

This places a `git fetch` call to retrieve the tags.
