### PR TITLE
feat: add standalone local environment with nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,97 @@ DISABLE_SSO_REDIRECT=true
 When this flag is enabled, the application will automatically create a default Django superuser (using the credentials defined in `DJANGO_SUPERUSER_USERNAME` and `DJANGO_SUPERUSER_PASSWORD`, or defaulting to `admin` / `admin123`) on startup.
 This allows direct access to the Django admin panel and the application without requiring the Shibboleth IdP containers.
 
+## Local Development Environment (Without SSO)
+
+For local development, it is possible to run the application without Shibboleth, LDAP, or the IdP services. This setup uses NGINX as a reverse proxy and static file server, while Django runs behind Gunicorn.
+
+### Environment Variables
+
+Ensure the following variables are present in `env/.env.dev`:
+
+```bash
+DEVELOPMENT=1
+DISABLE_SSO_REDIRECT=true
+```
+
+These settings disable SSO redirection and allow direct access to the application using Django authentication.
+
+### Architecture
+### Local Development Architecture
+
+```mermaid
+flowchart LR
+    Browser --> NGINX
+
+    subgraph Local Docker Environment
+        NGINX -->|Proxy| Django[Gunicorn / Django]
+
+        Django --> Postgres[(PostgreSQL)]
+        Django --> Redis[(Redis)]
+
+        Django --> Media[media/]
+
+        Collector[app_static_collector]
+        Collector --> Static[static_volume]
+
+        NGINX -->|Serve Static Files| Static
+    end
+
+    Note["SSO Components Not Required:
+    - websp
+    - openldap
+    - idp"]
+```
+
+### Required Services
+
+The local development environment consists of:
+
+* PostgreSQL
+* Redis
+* Django (Gunicorn)
+* Static File Collector
+* NGINX
+
+The following services are **not required**:
+
+* Shibboleth SP (websp)
+* LDAP
+* IdP
+
+### Media Directory
+
+Before starting the application, create the media directory used for uploaded files:
+
+```bash
+mkdir -p django/media
+```
+
+### Start the Local Environment
+
+Build and start all containers:
+
+```bash
+docker compose -f docker-compose.local.yml up --build
+```
+
+Once the containers are running, access the application at:
+
+```text
+http://localhost:8000
+```
+
+### Static Files
+
+Static files are collected automatically by the `app_static_collector` service and stored in a shared Docker volume. NGINX serves these files directly from `/staticfiles`, reproducing the behavior of the production deployment without requiring Shibboleth.
+
+### Uploaded Files
+
+Uploaded files are stored under the Django media directory. Ensure that the `django/media` directory exists before starting the containers.
+
+```
+```
+
 ### Access the GREN Map DB Node(s)
 
 URLs for the first DB Node server:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,75 @@
+services:
+  db:
+    image: postgres:13-alpine
+    env_file:
+      - ./env/.env.dev
+    ports:
+      - "54320:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+
+  redis:
+    image: bitnamilegacy/redis:7.0
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+
+  app:
+    build:
+      context: ./django
+      target: development
+    image: grenmap-django
+    volumes:
+      - ./django/:/home/grenmapadmin/web/
+      - static_volume:/home/grenmapadmin/web/staticfiles
+      - media_volume:/home/grenmapadmin/web/media
+    env_file:
+      - ./env/.env.dev
+    environment:
+      DEVELOPMENT: "1"
+      DISABLE_SSO_REDIRECT: "true"
+    command: gunicorn base_app.wsgi:application --bind 0.0.0.0:8080 --reload --log-level=debug --threads 4
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+      - redis
+    restart: unless-stopped
+    expose:
+      - "8080"
+
+  app_static_collector:
+    volumes:
+      - ./django/:/home/grenmapadmin/web/
+      - static_volume:/home/grenmapadmin/web/staticfiles
+    entrypoint: ./collect_static.sh
+    env_file:
+      - ./env/.env.dev
+    image: grenmap-django
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "8000:80"
+    depends_on:
+      - app
+    volumes:
+      - ./nginx/local.conf:/etc/nginx/conf.d/default.conf
+      - static_volume:/staticfiles
+
+  task_runner:
+    command: nodemon -e py --exec "python manage.py qcluster"
+    volumes:
+      - ./django/:/home/grenmapadmin/web/
+    env_file:
+      - ./env/.env.dev
+    entrypoint: ./task_runner.sh
+    depends_on:
+      - db
+      - app
+      - redis
+    image: grenmap-django
+
+volumes:
+  postgres_data:
+  static_volume:
+  media_volume:

--- a/nginx/local.conf
+++ b/nginx/local.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+
+    location /staticfiles/ {
+        alias /staticfiles/;
+        expires 1d;
+    }
+
+    location / {
+        proxy_pass http://app:8080;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
# Summary

This PR introduces a simplified local development environment that can be started with a single Docker Compose command, without requiring SSO/IDP services.

The new setup is intended to reduce onboarding effort and simplify local testing by running only the components required for application development.

# Changes

* Added `docker-compose.local.yml` for local development.
* Removed dependency on WebSP/SSO services in the local environment.
* Replaced WebSP with Nginx as the local reverse proxy.
* Added support for serving static files through Nginx.
* Added support for media file storage and uploads.
* Updated documentation with instructions for running the local environment and an architecture diagram.

# Validation

The following scenarios were successfully validated:

* Application startup using a single command.
* Django administration access using local credentials.
* Static asset delivery through Nginx.
* File upload functionality.
* Topology import processing through Django-Q.

# How to Run

```bash
docker compose -f docker-compose.local.yml up --build
```

The application will be available at:

```text
http://localhost:8000
```
